### PR TITLE
Fix K2SE circular dependency

### DIFF
--- a/info.json
+++ b/info.json
@@ -6,6 +6,6 @@
     "contact": "",
     "homepage": "https://discord.gg/kC53xn2",
     "factorio_version": "1.1",
-    "dependencies": ["base >= 1.1", "? bobvehicleequipment >= 1.0.0", "? alien-biomes >= 0.6.4", "? space-exploration-postprocess >= 0.5.10"],
+    "dependencies": ["base >= 1.1", "? bobvehicleequipment >= 1.0.0", "? alien-biomes >= 0.6.4", "? space-exploration >= 0.5.10"],
     "description": "Adds 13 new unique Spidertrons! Wether high firepower, early game, speed, inventory size or fog war reveal, there is something for everyone."
 }


### PR DESCRIPTION
Spidertron Tiers depending on Space Exploration Postprocess causes a circular dependency issue when K2 and Space Exploration are both enabled. 
 https://mods.factorio.com/mod/spidertrontiers/discussion/61d5fc14110e893576deac6b